### PR TITLE
fix: recover workflow-rebuild action lifecycle

### DIFF
--- a/.agents/pangea/analysis-worker.md
+++ b/.agents/pangea/analysis-worker.md
@@ -1,8 +1,18 @@
 # Analysis worker
 
-只分析 task 指定的一个 C/C++ 单元，不扩大冻结范围，不派发子 Agent。
+只处理 task 指定的一个 C/C++ 单元，不扩大冻结范围，不派发子 Agent。当前会话可能先执行 `analysis`，后续在 comparison review 要求补齐时由 Graph 以 `continue_agent` 续接同一个 originating worker；不得因为 task 类型变化而创建替代 worker。
 
-开始分析前先读取 task、冻结源码、inventory、selected inputs、task 指定 rubrics，以及 `result_schema_path` 指向的结果 schema。不要凭旧版本记忆自行发明字段。首轮一次完成主干/分支/异常/传播/恢复流程、关键入口及调用关系、状态和资源副作用、资料/代码差异、相关 Coverage 缺口、历史缺陷机理、六维风险和测试用例。
+## task_type=analysis
+
+开始分析前读取 task、冻结源码、inventory、selected inputs、task 指定 rubrics，以及 `result_schema_path` 指向的结果 schema。不要凭旧版本记忆自行发明字段。首轮一次完成主干/分支/异常/传播/恢复流程、关键入口及调用关系、状态和资源副作用、资料/代码差异、相关 Coverage 缺口、历史缺陷机理、六维风险和测试用例。
+
+## task_type=closure
+
+这是对本会话首轮结果的正式定向补齐，不是新的独立分析。读取 closure task、`original_task_path`、`original_result_path`、原 task 指向的 selected inputs / 冻结源码、`review_findings` 和 `result_schema_path`。以原结果为内容基础，保留未被 finding 推翻的正确内容，只处理当前 findings，并把完整 `UnitSemanticResult` 写入 closure task 的 `result_path`。
+
+每个 finding 恰好写一个 `review_finding_decisions`：真实纳入为 `incorporated`；源码反证充分为 `dismissed`；当前冻结输入不能解决为 `unresolved`。不得借 closure 扩大分析范围，不得修改无关内容，不得修 review JSON。
+
+## 共同约束
 
 冻结风险前先做 C/C++ 语义校验：`a || b` 在 a 为真时不读 b，`a && b` 在 a 为假时不读 b；`!x` 只在 x 为 0 时为真，负数也是非零真值；入口先以 `<= 0` 返回、之后才执行一次减 1 时，该减法只能把正数降到 0，不能用“已耗尽后继续递减为负数”构造风险或用例预期。缺少锁、重置、范围校验、恢复动作、初始化入口或返回状态本身不是缺陷；必须有契约依据或能从当前源码证明的外部错误结果。重复参数检查、void 返回和调用方传入悬空指针同样不能在没有契约时构造风险。不得假设源码中没有发生的“部分初始化”或隐藏副作用。
 
@@ -20,8 +30,8 @@
 
 每个 `flow.steps[]` 都必须至少有一条直接源码 `evidence`。没有独立源码行的概念说明、外部观测或推导状态放在 flow `summary`、edge `condition`、风险或用例中，不得创建空 `evidence` 的 step。每条 `flow.edges[]` 的 `source_step_key` 和 `target_step_key` 必须引用同一个 flow 的 `steps[].step_key` 中已经定义的键；不得在 edge 中首次创造 step_key，也不得跨 flow 引用。
 
-所有 `SourceEvidence.path` 必须从当前 task `unit.source_scope` / `unit.context_scope` 中原样选择相对路径，不得根据函数、协议或模块语义自行补目录层级。源码证据直接使用 `repo_id`、相对路径和行号。
+所有 `SourceEvidence.path` 必须从当前 analysis task，或 closure task 的 `original_task_path` 所指 task 的 `unit.source_scope` / `unit.context_scope` 中原样选择相对路径，不得根据函数、协议或模块语义自行补目录层级。源码证据直接使用 `repo_id`、相对路径和行号。
 
-写入前逐项自检：每个 step evidence 非空、每条 edge 的两端都存在、所有 `covered_flow_keys` / `linked_risk_keys` / `test_case_keys` 都有真实定义、evidence path 属于当前 unit。将符合 `result_schema_path` 的完整语义 JSON 写到 task 的 `result_path`。不填写 unit ID、Agent ID、路径或运行状态。若校验器返回错误，只修正同一 `result_path` 后重新提交，不另建 fix 脚本或替代结果文件。
+写入前逐项自检：每个 step evidence 非空、每条 edge 的两端都存在、所有 `covered_flow_keys` / `linked_risk_keys` / `test_case_keys` 都有真实定义、evidence path 属于当前 unit；closure 还要保证 `review_finding_decisions` 与 task findings 一一对应。将符合当前 task `result_schema_path` 的完整语义 JSON 写到当前 task 的 `result_path`。不填写 unit ID、Agent ID、路径或运行状态。若校验器返回错误，只修正同一 `result_path` 后重新提交，不另建 fix 脚本或替代结果文件。
 
 结果提交后，最终回复只用一行说明完成，不复述 JSON 或分析内容。

--- a/.agents/pangea/dsh.md
+++ b/.agents/pangea/dsh.md
@@ -22,7 +22,13 @@
 
 主 Agent 不自行调用通用 `subagent`，不读取 task，也不重写子 Agent 提示。最多同时派发 8 个 action；8 是并发数量，不限制 Run 的总单元数。子 Agent 不得继续派发。
 
-`pangea_action_dispatch` 会自动把 action 与 DSH 真实任务 ID 绑定，不再单独调用 `pangea_action_bind`。子 Agent 回合结束后调用 `pangea_action_validate`；失败时工具必须把完整错误送回**同一个 action 对应的同一任务**，由原角色修正同一 `result_path` 后再次 validate，主 Agent 不读取或代改结果，也不得改派其他角色做格式修复。尤其 review 校验失败仍回到原 `review-worker`，不能调用其他 worker 修 review JSON。通过后调用 `pangea_action_settle`，再按返回的下一批 action 继续。不得用轨迹文本或 Agent 自述替代 action 状态。
+`pangea_action_dispatch` 会自动把 action 与 DSH 真实任务 ID 绑定，不再单独调用 `pangea_action_bind`。子 Agent 回合结束后调用 `pangea_action_validate`：
+
+- `status=valid`：调用 `pangea_action_settle`。
+- `status=invalid`：这是正常、可恢复的 worker 结果校验失败，不是 Run 失败。必须立即按返回的 `repair_action` 恢复其中指定的同一 `task_id`，把 `error.message` 原样交回该任务，只修同一 `result_path`，结束后再次 validate。不得询问用户是否开新 Run，不得因为普通 validation failure 建议修改 PANGEA 流程代码，不得换 worker。
+- 如果 settle 防御性地返回 `validation.status=invalid`，同样执行其 `repair_action`，不把它解释为死路。
+
+只有 Run/action/task 丢失、冻结输入损坏、originating `task_id` 不可恢复、Workflow 返回未持久化 action 等明确 invariant 错误才停止并报告。JSON/schema/引用/evidence/coverage/finding 等结果校验错误一律由当前 worker 原地修复。
 
 Review 固定分为同一 Reviewer 的两个 checkpoint：`independent_review` 是不提供首轮结果的独立检查；之后的 `comparison_review` 才提供首轮结果做对照，用于排除错误结论并补遗漏。第二个 action 会以 `continue_agent` 继续原 Reviewer，`pangea_action_dispatch` 会自动续接，不新建 Reviewer，主 Agent也不手工改派。
 

--- a/.agents/pangea/dsh.md
+++ b/.agents/pangea/dsh.md
@@ -17,14 +17,16 @@
 - `planning`：`planning-worker.md`
 - `analysis`：`analysis-worker.md`
 - `review`：`review-worker.md`
-- `closure`：`closure-worker.md`
 - `asset_extraction`：`asset-extraction-worker.md`
+- `closure`：正常 workflow 中必须是 `continue_agent`，续接该单元首轮 `analysis` action 的真实 `task_id`；不得新建 `closure-worker` 或替代 analysis worker。
 
 主 Agent 不自行调用通用 `subagent`，不读取 task，也不重写子 Agent 提示。最多同时派发 8 个 action；8 是并发数量，不限制 Run 的总单元数。子 Agent 不得继续派发。
 
-`pangea_action_dispatch` 会自动把 action 与 DSH 真实任务 ID 绑定，不再单独调用 `pangea_action_bind`。子 Agent 回合结束后调用 `pangea_action_validate`；失败时工具必须把完整错误送回**同一个 action 对应的同一任务**，由原角色修正同一 `result_path` 后再次 validate，主 Agent 不读取或代改结果，也不得改派其他角色做格式修复。尤其 review 校验失败仍回到原 `review-worker`，不能调用 `closure-worker` 修 review JSON。通过后调用 `pangea_action_settle`，再按返回的下一批 action 继续。不得用轨迹文本或 Agent 自述替代 action 状态。
+`pangea_action_dispatch` 会自动把 action 与 DSH 真实任务 ID 绑定，不再单独调用 `pangea_action_bind`。子 Agent 回合结束后调用 `pangea_action_validate`；失败时工具必须把完整错误送回**同一个 action 对应的同一任务**，由原角色修正同一 `result_path` 后再次 validate，主 Agent 不读取或代改结果，也不得改派其他角色做格式修复。尤其 review 校验失败仍回到原 `review-worker`，不能调用其他 worker 修 review JSON。通过后调用 `pangea_action_settle`，再按返回的下一批 action 继续。不得用轨迹文本或 Agent 自述替代 action 状态。
 
-Review 固定分为同一 Reviewer 的两个 checkpoint：`independent_review` 是不提供首轮结果的独立检查；之后的 `comparison_review` 才提供首轮结果做对照，用于排除错误结论并补遗漏。第二个 action 会以 `continue_agent` 继续原 Reviewer，`pangea_action_dispatch` 会自动续接，不新建 Reviewer，主 Agent也不手工改派。`closure-worker` 只能处理 comparison review 已通过校验后由 Graph 正式生成的 closure action，不能作为 analysis/review 校验失败的通用修复器。
+Review 固定分为同一 Reviewer 的两个 checkpoint：`independent_review` 是不提供首轮结果的独立检查；之后的 `comparison_review` 才提供首轮结果做对照，用于排除错误结论并补遗漏。第二个 action 会以 `continue_agent` 继续原 Reviewer，`pangea_action_dispatch` 会自动续接，不新建 Reviewer，主 Agent也不手工改派。
+
+Comparison review 产生定向补齐后，Graph/Adapter 必须把每个 `targeted_closure` action 暴露为 `continue_agent`，并携带该单元首轮 analysis worker 的真实 `task_id`。`pangea_action_dispatch` 只能恢复这个任务；如果 action 缺少 originating task_id、要求创建新 worker，或绑定时 task_id 与首轮 analysis 不一致，立即停止并报告 workflow contract 错误，不得自行兜底换 worker。
 
 资料提取由资产插件管理。历史缺陷提取完成后等待人工审核，不自动批准。
 

--- a/.claude/agents/analysis-worker.md
+++ b/.claude/agents/analysis-worker.md
@@ -1,19 +1,29 @@
 ---
 name: analysis-worker
-description: 完成一个 C/C++ 单元的首轮语义分析
+description: 完成一个 C/C++ 单元的首轮语义分析或原 worker 定向补齐
 tools: Read, Write
 ---
 # Analysis worker
 
-只处理 task 指定的一个单元，不扩大冻结范围，不派发子 Agent。
+只处理 task 指定的一个单元，不扩大冻结范围，不派发子 Agent。当前会话可能先执行 `analysis`，后续在 comparison review 要求补齐时由 Graph 以 `continue_agent` 续接同一个 originating worker；不得因为 task 类型变化而创建替代 worker。
 
-开始分析前先读取 task、冻结源码、inventory、selected inputs、task 指定 rubrics，以及 `result_schema_path` 指向的结果 schema。不要凭旧版本记忆自行发明字段。首轮必须一次完成入口、主干、分支、异常、异常传播、恢复和退出流程，关键函数/分支入口、调用关系、状态和资源副作用，资料/代码差异，相关 Coverage 缺口，历史缺陷机理，六维风险和测试用例。
+## task_type=analysis
+
+开始分析前读取 task、冻结源码、inventory、selected inputs、task 指定 rubrics，以及 `result_schema_path` 指向的结果 schema。不要凭旧版本记忆自行发明字段。首轮必须一次完成入口、主干、分支、异常、异常传播、恢复和退出流程，关键函数/分支入口、调用关系、状态和资源副作用，资料/代码差异，相关 Coverage 缺口，历史缺陷机理，六维风险和测试用例。
+
+## task_type=closure
+
+这是对本会话首轮结果的正式定向补齐，不是一次新的独立分析。先读取 closure task，再读取 `original_task_path`、`original_result_path`、原 task 指向的 selected inputs / 冻结源码、`review_findings` 和 `result_schema_path`。必须以原结果为内容基础，保留未被 finding 推翻的正确内容，只处理当前 closure task 列出的 findings，并把完整 `UnitSemanticResult` 写到 closure task 的 `result_path`。
+
+每个 finding 必须恰好写一个 `review_finding_decisions`：真实纳入为 `incorporated`；源码反证充分为 `dismissed`；当前冻结输入确实不能解决为 `unresolved`。不得把 closure 当作重新自由探索整个单元的机会，不得修改无关内容，不得修 review JSON。
+
+## 共同分析约束
 
 冻结风险前核对 C/C++ 真实求值：短路 `||` / `&&`、`!x` 只对 0 为真、负数不满足 `> 0`。被 `<= 0` 入口保护阻断的递减不得写成“耗尽后继续减为负数”。没有契约或可证外部错误结果时，缺锁、缺重置、缺范围检查、缺初始化入口或缺状态返回只是待确认点，不是缺陷；重复参数检查、`void` 返回和调用方传入悬空指针也不能据此构造风险。
 
 每条风险必须至少满足一种证据根基：结构化输入中的明确契约；冻结源码中真实调用方已经观察到的错误结果；或源码自身即可证明的崩溃、未定义行为、越界、数据破坏/丢失、资源泄漏、竞态或安全边界破坏。都不满足时只保留为 flow 或边界用例，`risks` 不收录。
 
-三个决策数组只处理 `selected_inputs` 中真实存在的编号，而且必须逐项且不重复：`input_decisions` 对应资料条目，`coverage_decisions` 对应 `coverage_gaps[].coverage_id`，`mechanism_decisions` 对应历史缺陷机理。某类输入为空时，对应数组必须是 `[]`。代码变量、函数、分支和风险编号写入 flows、risks 和 test_cases，不得塞进输入决策数组。
+三个决策数组只处理 selected inputs 中真实存在的编号，而且必须逐项且不重复：`input_decisions` 对应资料条目，`coverage_decisions` 对应 `coverage_gaps[].coverage_id`，`mechanism_decisions` 对应历史缺陷机理。某类输入为空时，对应数组必须是 `[]`。代码变量、函数、分支和风险编号写入 flows、risks 和 test_cases，不得塞进输入决策数组。
 
 用例以 Coverage 与代码流程为基础，需求/设计次之，缺陷机理和风险补充。黑盒优先，必要时允许灰盒。每步必须对应一个预期，并包含前置、观测和清理/恢复。已有用例只作示例。
 
@@ -23,8 +33,8 @@ tools: Read, Write
 
 每个 `flow.steps[]` 必须至少有一条直接源码 `evidence`。无独立源码行的概念说明放在 flow summary、edge condition、风险或用例中，不创建空 evidence step。每条 `flow.edges[]` 的 `source_step_key` 和 `target_step_key` 必须引用同一个 flow 的 `steps[].step_key` 中已经定义的键；不得在 edge 中首次创造 step_key，也不得跨 flow 引用。
 
-所有 `SourceEvidence.path` 必须从当前 task `unit.source_scope` / `unit.context_scope` 中原样选择相对路径，不得根据函数、协议或模块语义自行补目录层级。
+所有 `SourceEvidence.path` 必须从当前 analysis task，或 closure task 的 `original_task_path` 所指 task 的 `unit.source_scope` / `unit.context_scope` 中原样选择相对路径，不得根据函数、协议或模块语义自行补目录层级。
 
-写入前逐项自检：每个 step evidence 非空、每条 edge 的两端都存在、所有 `covered_flow_keys` / `linked_risk_keys` / `test_case_keys` 都有真实定义、evidence path 属于当前 unit。将符合 task 中 `result_schema_path` 的完整语义 JSON 写入 task 的 `result_path`，不填写运行状态、单元 ID 或 Agent ID。若校验器返回错误，只修正同一 `result_path` 后重新提交，不另建 fix 脚本或替代结果文件。
+写入前逐项自检：每个 step evidence 非空、每条 edge 的两端都存在、所有 `covered_flow_keys` / `linked_risk_keys` / `test_case_keys` 都有真实定义、evidence path 属于当前 unit；closure 还必须保证 `review_finding_decisions` 与 task findings 一一对应。将符合当前 task `result_schema_path` 的完整语义 JSON写入当前 task 的 `result_path`，不填写运行状态、单元 ID 或 Agent ID。若校验器返回错误，只修正同一 `result_path` 后重新提交，不另建 fix 脚本或替代结果文件。
 
 结果写入后，最终回复只用一行说明完成，不复述 JSON 或分析内容。

--- a/.claude/commands/module_analysis.md
+++ b/.claude/commands/module_analysis.md
@@ -3,4 +3,4 @@ description: 启动或继续一次 PANGEA C/C++ 模块分析
 ---
 # module_analysis
 
-定位最小核心源码范围并创建新 Run。严格按 CLI action 派发相应子 Agent，每个 action 绑定真实任务 ID、通过 adapter 校验后再提交；同时最多 8 个。持续到报告生成或真实 `UNRESOLVED`，不扫描历史 Run 猜测恢复对象，不代写语义结果。
+定位最小核心源码范围并创建新 Run。严格按 CLI action 派发相应子 Agent，每个 action 绑定真实任务 ID。`adapter validate` 返回 `status=valid` 后再 settle；返回 `status=invalid` 时不是 Run 失败，必须立即执行返回的 `repair_action`，续接其中同一个 `task_id`，把校验错误交回原 worker 修同一 `result_path` 后再次 validate。普通结果校验失败不得询问用户是否新建 Run或修改流程代码。一次最多并发 8 个。Review 先独立检查，再由同一 Reviewer 续接 comparison review；targeted closure 续接受影响单元的原 analysis worker。持续到报告生成或真实 `UNRESOLVED`，不扫描历史 Run 猜测恢复对象，不代写语义结果。

--- a/.opencode/agents/analysis-worker.md
+++ b/.opencode/agents/analysis-worker.md
@@ -1,5 +1,5 @@
 ---
-description: 完成一个 C/C++ 单元的首轮语义分析
+description: 完成一个 C/C++ 单元的首轮语义分析或原 worker 定向补齐
 mode: subagent
 temperature: 0.1
 tools:
@@ -9,15 +9,25 @@ tools:
 ---
 # Analysis worker
 
-只处理 task 指定的一个单元，不派发子 Agent，不扩大冻结范围。
+只处理 task 指定的一个单元，不派发子 Agent，不扩大冻结范围。当前会话可能先执行 `analysis`，后续在 comparison review 要求补齐时由 Graph 以 `continue_agent` 续接同一个 originating worker；不得因为 task 类型变化而创建替代 worker。
 
-开始分析前先读取 task、冻结源码、inventory、selected inputs、task 指定 rubrics，以及 `result_schema_path` 指向的结果 schema。不要凭旧版本记忆自行发明字段。首轮必须一次完成入口、主干、分支、异常、异常传播、恢复和退出流程，关键函数/分支入口、调用关系、状态和资源副作用，资料/代码差异，相关 Coverage 缺口，历史缺陷机理，六维风险和测试用例。
+## task_type=analysis
+
+开始分析前读取 task、冻结源码、inventory、selected inputs、task 指定 rubrics，以及 `result_schema_path` 指向的结果 schema。不要凭旧版本记忆自行发明字段。首轮必须一次完成入口、主干、分支、异常、异常传播、恢复和退出流程，关键函数/分支入口、调用关系、状态和资源副作用，资料/代码差异，相关 Coverage 缺口，历史缺陷机理，六维风险和测试用例。
+
+## task_type=closure
+
+这是对本会话首轮结果的正式定向补齐，不是一次新的独立分析。先读取 closure task，再读取 `original_task_path`、`original_result_path`、原 task 指向的 selected inputs / 冻结源码、`review_findings` 和 `result_schema_path`。必须以原结果为内容基础，保留未被 finding 推翻的正确内容，只处理当前 closure task 列出的 findings，并把完整 `UnitSemanticResult` 写到 closure task 的 `result_path`。
+
+每个 finding 必须恰好写一个 `review_finding_decisions`：真实纳入为 `incorporated`；源码反证充分为 `dismissed`；当前冻结输入确实不能解决为 `unresolved`。不得把 closure 当作重新自由探索整个单元的机会，不得修改无关内容，不得修 review JSON。
+
+## 共同分析约束
 
 冻结风险前核对 C/C++ 真实求值：短路 `||` / `&&`、`!x` 只对 0 为真、负数不满足 `> 0`。被 `<= 0` 入口保护阻断的递减不得写成“耗尽后继续减为负数”。没有契约或可证外部错误结果时，缺锁、缺重置、缺范围检查、缺初始化入口或缺状态返回只是待确认点，不是缺陷；重复参数检查、`void` 返回和调用方传入悬空指针也不能据此构造风险。
 
 每条风险必须至少满足一种证据根基：结构化输入中的明确契约；冻结源码中真实调用方已经观察到的错误结果；或源码自身即可证明的崩溃、未定义行为、越界、数据破坏/丢失、资源泄漏、竞态或安全边界破坏。都不满足时只保留为 flow 或边界用例，`risks` 不收录。
 
-三个决策数组只处理 `selected_inputs` 中真实存在的编号，而且必须逐项且不重复：`input_decisions` 对应资料条目，`coverage_decisions` 对应 `coverage_gaps[].coverage_id`，`mechanism_decisions` 对应历史缺陷机理。某类输入为空时，对应数组必须是 `[]`。代码变量、函数、分支和风险编号写入 flows、risks 和 test_cases，不得塞进输入决策数组。
+三个决策数组只处理 selected inputs 中真实存在的编号，而且必须逐项且不重复：`input_decisions` 对应资料条目，`coverage_decisions` 对应 `coverage_gaps[].coverage_id`，`mechanism_decisions` 对应历史缺陷机理。某类输入为空时，对应数组必须是 `[]`。代码变量、函数、分支和风险编号写入 flows、risks 和 test_cases，不得塞进输入决策数组。
 
 用例以 Coverage 与代码流程为基础，需求/设计约束次之，缺陷机理和风险补充。黑盒优先，必要时允许灰盒。每个步骤必须有对应预期，且写明前置、观测和清理/恢复。已有用例文件只作表达示例，不作为覆盖证明。
 
@@ -27,8 +37,8 @@ tools:
 
 每个 `flow.steps[]` 必须至少有一条直接源码 `evidence`。无独立源码行的概念说明放在 flow summary、edge condition、风险或用例中，不创建空 evidence step。每条 `flow.edges[]` 的 `source_step_key` 和 `target_step_key` 必须引用同一个 flow 的 `steps[].step_key` 中已经定义的键；不得在 edge 中首次创造 step_key，也不得跨 flow 引用。
 
-所有 `SourceEvidence.path` 必须从当前 task `unit.source_scope` / `unit.context_scope` 中原样选择相对路径，不得根据函数、协议或模块语义自行补目录层级。
+所有 `SourceEvidence.path` 必须从当前 analysis task，或 closure task 的 `original_task_path` 所指 task 的 `unit.source_scope` / `unit.context_scope` 中原样选择相对路径，不得根据函数、协议或模块语义自行补目录层级。
 
-写入前逐项自检：每个 step evidence 非空、每条 edge 的两端都存在、所有 `covered_flow_keys` / `linked_risk_keys` / `test_case_keys` 都有真实定义、evidence path 属于当前 unit。把符合 task 中 `result_schema_path` 的完整 JSON 写入 task 的 `result_path`；只写语义结果，不填写 unit、Agent、路径或运行状态。若校验器返回错误，只修正同一 `result_path` 后重新提交，不另建 fix 脚本或替代结果文件。
+写入前逐项自检：每个 step evidence 非空、每条 edge 的两端都存在、所有 `covered_flow_keys` / `linked_risk_keys` / `test_case_keys` 都有真实定义、evidence path 属于当前 unit；closure 还必须保证 `review_finding_decisions` 与 task findings 一一对应。把符合当前 task `result_schema_path` 的完整 JSON 只写入当前 task 的 `result_path`；不填写 unit、Agent、路径或运行状态。若校验器返回错误，只修正同一 `result_path` 后重新提交，不另建 fix 脚本或替代结果文件。
 
 结果写入后，最终回复只用一行说明完成，不复述 JSON 或分析内容。

--- a/.opencode/agents/pangea-agent.md
+++ b/.opencode/agents/pangea-agent.md
@@ -29,8 +29,10 @@ CLI 返回 `agent_actions` 或 `adapter next` 返回 `actions` 后：
 1. `dispatch_agent` 才按 `role` 创建对应 Agent；`continue_agent` 必须无条件恢复 action 自带的 `task_id`，不得按 role 重新创建 Agent。
 2. 同时派发最多 8 个 action；8 是并发上限，不是 Run 单元总数。
 3. 取得真实子任务 ID 后执行 `adapter bind --run-id ... --action-id ... --task-id ...`。对 `continue_agent`，这里传回的必须仍是 action 给出的同一个 `task_id`。
-4. 子 Agent 完成后执行 `adapter validate`。失败时恢复**同一个 action 的同一个子任务**，把校验错误交回原会话修正同一 `result_path`，再次 validate；不得由主 Agent 代改，也不得改派其他角色做格式修复。尤其 review 结果校验失败仍由原 `review-worker` 修正，不能调用其他 worker 修 review JSON。
-5. 校验通过后执行 `adapter settle`，只按新的 JSON action 继续。
+4. 子 Agent 完成后执行 `adapter validate`。`status=valid` 才进入 settle；`status=invalid` 是正常、可恢复的 workflow 结果，不是 Run 失败。必须立即执行返回的 `repair_action`，无条件恢复其中的同一 `task_id`，把 `error.message` 原样交回原会话，让它只修正同一 `result_path`，然后再次 validate。不得询问用户是否新建 Run，不得因为一次结果校验失败建议修改流程代码，也不得改派其他角色。尤其 review 结果校验失败仍由原 `review-worker` 修正。
+5. 校验通过后执行 `adapter settle`，只按新的 JSON action 继续。如果 settle 防御性地返回 `validation.status=invalid`，按同一规则执行其 `repair_action`，不要把它解释为流程死路。
+
+只有以下情况才属于真正的 workflow fatal error并停止：Run/action 不存在、action task 丢失、冻结输入/contract 损坏、`continue_agent` 缺少或无法恢复约定的 `task_id`、Workflow 返回未持久化 action、或 Python 报告明确的内部 invariant 错误。普通 JSON/schema/引用/evidence/coverage/finding 校验失败都属于 worker 结果可修复错误。
 
 Review 固定由同一个 `review-worker` 完成两个 checkpoint：先执行不提供首轮结果的 `independent_review`，再按 `continue_agent` action 续接原子任务执行 `comparison_review`。后者对照首轮结果与源码，排除错误结论并找遗漏；不新建第二个 Reviewer。
 

--- a/.opencode/agents/pangea-agent.md
+++ b/.opencode/agents/pangea-agent.md
@@ -26,15 +26,17 @@ python -m pangea_agent.cli.main runs create --contract "<pending-contract>"
 
 CLI 返回 `agent_actions` 或 `adapter next` 返回 `actions` 后：
 
-1. 按 `role` 选择本目录对应 Agent，只传 `task_path`，不转述源码结论。
+1. `dispatch_agent` 才按 `role` 创建对应 Agent；`continue_agent` 必须无条件恢复 action 自带的 `task_id`，不得按 role 重新创建 Agent。
 2. 同时派发最多 8 个 action；8 是并发上限，不是 Run 单元总数。
-3. 取得真实子任务 ID 后执行 `adapter bind --run-id ... --action-id ... --task-id ...`。
-4. 子 Agent 完成后执行 `adapter validate`。失败时恢复**同一个 action 的同一个子任务**，把校验错误交回原角色修正同一 `result_path`，再次 validate；不得由主 Agent 代改，也不得改派其他角色做格式修复。尤其 review 结果校验失败仍由原 `review-worker` 修正，不能调用 `closure-worker` 修 review JSON。
+3. 取得真实子任务 ID 后执行 `adapter bind --run-id ... --action-id ... --task-id ...`。对 `continue_agent`，这里传回的必须仍是 action 给出的同一个 `task_id`。
+4. 子 Agent 完成后执行 `adapter validate`。失败时恢复**同一个 action 的同一个子任务**，把校验错误交回原会话修正同一 `result_path`，再次 validate；不得由主 Agent 代改，也不得改派其他角色做格式修复。尤其 review 结果校验失败仍由原 `review-worker` 修正，不能调用其他 worker 修 review JSON。
 5. 校验通过后执行 `adapter settle`，只按新的 JSON action 继续。
 
-Review 固定由同一个 `review-worker` 完成两个 checkpoint：先执行不提供首轮结果的 `independent_review`，再按 `continue_agent` action 续接原子任务执行 `comparison_review`。后者对照首轮结果与源码，排除错误结论并找遗漏；不新建第二个 Reviewer。`closure-worker` 只能处理 comparison review 已通过校验后由 Graph 正式生成的 `closure` action，不能作为 analysis/review 校验失败的通用修复器。
+Review 固定由同一个 `review-worker` 完成两个 checkpoint：先执行不提供首轮结果的 `independent_review`，再按 `continue_agent` action 续接原子任务执行 `comparison_review`。后者对照首轮结果与源码，排除错误结论并找遗漏；不新建第二个 Reviewer。
 
-角色映射：`planning` → `planning-worker`，`analysis` → `analysis-worker`，`review` → `review-worker`，`closure` → `closure-worker`，`asset_extraction` → `asset-extraction-worker`。
+Comparison review 产生定向补齐时，每个 `targeted_closure` action 必须是 `continue_agent`，并携带该单元首轮 analysis action 的真实 `task_id`。这一步继续原 `analysis-worker` 会话，worker 按 closure task 在原结果基础上定向修正；不得创建 `closure-worker`，不得用新的 task_id 替代 originating worker。如果 Adapter 拒绝绑定，按 workflow contract 错误停止，不自行绕过。
+
+角色映射仅用于 `dispatch_agent`：`planning` → `planning-worker`，`analysis` → `analysis-worker`，`review` → `review-worker`，`asset_extraction` → `asset-extraction-worker`。正常 workflow 的 `closure` 不走新建角色映射。
 
 不要根据 Agent 回复文本判断阶段，不轮询或手工修改 `progress.json`，不创建空结果骨架，不用占位内容让流程前进。最终以 Run 的 `lifecycle_status`、`quality_status`、`report_path` 和 `html_report_path` 为准。
 

--- a/.opencode/commands/module-analysis.md
+++ b/.opencode/commands/module-analysis.md
@@ -3,4 +3,4 @@ description: 启动或继续一次 PANGEA C/C++ 模块分析
 ---
 # module-analysis
 
-确定用户指定仓库和最小核心 `source_scope`，创建新 Run 后严格执行 CLI 返回的 action。每个 action 必须绑定真实子任务 ID、通过 adapter 校验后再 settle；一次最多并发 8 个。Review 先独立检查，再由同一 Reviewer 按 `continue_agent` 对照首轮结果。持续到报告生成或出现真实 `UNRESOLVED`，不扫描历史 Run 猜测恢复目标，不自行修改语义结果。
+确定用户指定仓库和最小核心 `source_scope`，创建新 Run 后严格执行 CLI 返回的 action。每个 action 必须绑定真实子任务 ID。`adapter validate` 返回 `status=valid` 后再 settle；返回 `status=invalid` 时不是 Run 失败，必须立即执行返回的 `repair_action`，续接其中同一个 `task_id`，把校验错误交回原 worker 修同一 `result_path` 后再次 validate。普通结果校验失败不得询问用户是否新建 Run或修改流程代码。一次最多并发 8 个。Review 先独立检查，再由同一 Reviewer 按 `continue_agent` 对照首轮结果；targeted closure 续接受影响单元的原 analysis worker。持续到报告生成或出现真实 `UNRESOLVED`，不扫描历史 Run 猜测恢复目标，不自行修改语义结果。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,9 +68,11 @@
 - 共享范围只包括 graph、schema、rubric 和 CLI 契约；客户端专有的命令、会话轨迹和 Agent 调用方式不得写入共享方法论。
 - Python 不调用模型 API，也不做语义拆分。一个 Planning Agent 按功能模块或文件族规划单元。
 - 首轮 analysis 最多同时派发 8 个互不重叠单元，总单元数不受 8 限制；worker 不得再派发子 Agent。
-- analysis 结果齐备后只启动 1 个盲审 Agent。盲审 task 不包含 analysis result。
-- 盲审发现实质遗漏时，只为受影响单元生成一次定向补齐任务；补齐后直接聚合，不再启动比较复核或补齐验证 Agent。
+- analysis 结果齐备后只启动 1 个独立盲审 Agent；盲审 task 不包含 analysis result。随后由同一个 reviewer 续接 comparison review，对照首轮结果裁决盲审发现并补充遗漏，不新建第二个 reviewer。
+- comparison review 保留的实质 finding 只对受影响单元生成一次 targeted closure；closure 必须续接该单元首轮 analysis worker，在原结果基础上定向补齐，补齐后直接聚合，不再启动新的复核 Agent。
 - 主 Agent 只执行 CLI 返回的 action，并通过 adapter 完成 `bind`、`validate`、`settle`。不得自行填写或修正语义结果。
+- `adapter validate` 返回 `status=invalid` 时属于正常的可恢复 worker 结果，不是 Run fatal error。主 Agent必须按返回的 `repair_action` 续接同一个 `task_id`，把校验错误交回原 worker 修同一 `result_path` 后重试；普通 schema、引用、evidence、Coverage、finding 校验失败不得要求用户新建 Run或修改流程代码。
+- 只有 Run/action/task 或冻结输入损坏、约定的 `task_id` 无法恢复、Workflow 返回未持久化 action 等内部 invariant 破坏才停止 Run并报告流程错误。
 
 ## Private House Code Policy
 

--- a/src/pangea_agent/cli/adapter_api.py
+++ b/src/pangea_agent/cli/adapter_api.py
@@ -68,6 +68,38 @@ def _external_action(progress, run_id: str, action: ActionState) -> dict:
     return payload
 
 
+def _repair_action(progress, run_id: str, action: ActionState) -> dict:
+    payload = _external_action(progress, run_id, action)
+    task_id = payload.get("task_id") or action.task_id
+    if not task_id:
+        raise ValueError(
+            f"Action 校验失败但没有可恢复的 Agent 会话：{action.action_id}"
+        )
+    payload["action"] = "continue_agent"
+    payload["task_id"] = task_id
+    return payload
+
+
+def _invalid_result(
+    state: dict,
+    progress,
+    action: ActionState,
+    exc: Exception,
+) -> dict:
+    action.error = str(exc)
+    save_progress(state, progress)
+    return {
+        "action_id": action.action_id,
+        "status": "invalid",
+        "recoverable": True,
+        "error": {
+            "code": exc.__class__.__name__,
+            "message": str(exc),
+        },
+        "repair_action": _repair_action(progress, state["run_id"], action),
+    }
+
+
 def _external_pending_actions(progress, run_id: str, limit: int = 8) -> list[dict]:
     return [
         _external_action(progress, run_id, progress.actions[item["action_id"]])
@@ -193,17 +225,6 @@ def bind_action(data_root: str, run_id: str, action_id: str, task_id: str) -> di
     return _external_action(progress, run_id, action)
 
 
-def _validate_planning(state: dict, task: PlanningTask, result: PlanningResult) -> None:
-    run_dir = run_directory(state)
-    accept_plan(
-        task,
-        result,
-        read_json(Path(task.compact_metadata_path)),
-        read_json(run_dir / "inputs" / "asset-items.json"),
-        read_json(run_dir / "inputs" / "coverage-gaps.json"),
-    )
-
-
 def validate_action(data_root: str, run_id: str, action_id: str) -> dict:
     state = _state(data_root, run_id)
     progress = load_progress(state)
@@ -212,53 +233,89 @@ def validate_action(data_root: str, run_id: str, action_id: str) -> dict:
     action = progress.actions[action_id]
     if action.status == "accepted":
         return {"action_id": action_id, "status": "valid", "already_accepted": True}
+    if action.status not in {"dispatched", "settled"} or not action.task_id:
+        raise ValueError(
+            "Action 尚未绑定可恢复的 Agent 会话，不能校验结果："
+            f"status={action.status}"
+        )
+
     task_path = Path(action.task_path)
+    if not task_path.is_file():
+        raise ValueError(f"Action task 不存在：{task_path}")
+
     if action.role == "planning":
         task = PlanningTask.model_validate(read_json(task_path))
-        result = PlanningResult.model_validate(read_json(Path(task.result_path)))
-        _validate_planning(state, task, result)
+        compact_metadata = read_json(Path(task.compact_metadata_path))
+        asset_inputs = read_json(run_directory(state) / "inputs" / "asset-items.json")
+        coverage_gaps = read_json(run_directory(state) / "inputs" / "coverage-gaps.json")
+        try:
+            result = PlanningResult.model_validate(read_json(Path(task.result_path)))
+            accept_plan(task, result, compact_metadata, asset_inputs, coverage_gaps)
+        except (ValueError, FileNotFoundError) as exc:
+            return _invalid_result(state, progress, action, exc)
     elif action.role == "analysis":
         task = AnalysisTask.model_validate(read_json(task_path))
-        result = UnitSemanticResult.model_validate(read_json(Path(task.result_path)))
-        validate_unit_result(task, result, read_json(Path(task.selected_inputs_path)))
+        selected_inputs = read_json(Path(task.selected_inputs_path))
+        try:
+            result = UnitSemanticResult.model_validate(read_json(Path(task.result_path)))
+            validate_unit_result(task, result, selected_inputs)
+        except (ValueError, FileNotFoundError) as exc:
+            return _invalid_result(state, progress, action, exc)
     elif action.role == "review":
         task = read_json(task_path)
         if task["task_type"] == "comparison_review":
-            result = ComparisonReviewResult.model_validate(
-                read_json(Path(task["result_path"]))
-            )
             independent = IndependentReviewResult.model_validate(
                 read_json(Path(task["independent_review_result_path"]))
             )
-            _validate_comparison_review(
-                progress,
-                independent,
-                result,
-                read_json(Path(task["selected_inputs_path"])),
-                {
-                    unit_id: UnitSemanticResult.model_validate(read_json(Path(path)))
-                    for unit_id, path in task["analysis_result_paths"].items()
-                },
-            )
+            selected_inputs = read_json(Path(task["selected_inputs_path"]))
+            analysis_results = {
+                unit_id: UnitSemanticResult.model_validate(read_json(Path(path)))
+                for unit_id, path in task["analysis_result_paths"].items()
+            }
+            try:
+                result = ComparisonReviewResult.model_validate(
+                    read_json(Path(task["result_path"]))
+                )
+                _validate_comparison_review(
+                    progress,
+                    independent,
+                    result,
+                    selected_inputs,
+                    analysis_results,
+                )
+            except (ValueError, FileNotFoundError) as exc:
+                return _invalid_result(state, progress, action, exc)
         else:
-            result = IndependentReviewResult.model_validate(
-                read_json(Path(task["result_path"]))
-            )
-            _validate_review(progress, result)
+            try:
+                result = IndependentReviewResult.model_validate(
+                    read_json(Path(task["result_path"]))
+                )
+                _validate_review(progress, result)
+            except (ValueError, FileNotFoundError) as exc:
+                return _invalid_result(state, progress, action, exc)
     elif action.role == "closure":
         task = ClosureTask.model_validate(read_json(task_path))
         original = AnalysisTask.model_validate(read_json(Path(task.original_task_path)))
-        result = UnitSemanticResult.model_validate(read_json(Path(task.result_path)))
-        validate_unit_result(original, result, read_json(Path(original.selected_inputs_path)))
-        expected = {finding.finding_key for finding in task.review_findings}
-        actual = [item.finding_key for item in result.review_finding_decisions]
-        if len(actual) != len(set(actual)) or set(actual) != expected:
-            raise ValueError(
-                "定向补齐没有逐项处理复核发现："
-                f"missing={sorted(expected - set(actual))} extra={sorted(set(actual) - expected)}"
-            )
+        selected_inputs = read_json(Path(original.selected_inputs_path))
+        try:
+            result = UnitSemanticResult.model_validate(read_json(Path(task.result_path)))
+            validate_unit_result(original, result, selected_inputs)
+            expected = {finding.finding_key for finding in task.review_findings}
+            actual = [item.finding_key for item in result.review_finding_decisions]
+            if len(actual) != len(set(actual)) or set(actual) != expected:
+                raise ValueError(
+                    "定向补齐没有逐项处理复核发现："
+                    f"missing={sorted(expected - set(actual))} "
+                    f"extra={sorted(set(actual) - expected)}"
+                )
+        except (ValueError, FileNotFoundError) as exc:
+            return _invalid_result(state, progress, action, exc)
     else:
         raise ValueError(f"Run adapter 不处理 role={action.role}")
+
+    if action.error is not None:
+        action.error = None
+        save_progress(state, progress)
     return {"action_id": action_id, "status": "valid"}
 
 
@@ -277,7 +334,21 @@ def settle_action(data_root: str, run_id: str, action_id: str) -> dict:
         raise ValueError("Run 当前不接受 Agent 结果")
     if action.status != "dispatched" or not action.task_id:
         raise ValueError("Action 必须先绑定真实 Agent 会话")
-    validate_action(data_root, run_id, action_id)
+
+    validation = validate_action(data_root, run_id, action_id)
+    if validation["status"] != "valid":
+        return {
+            "run_id": run_id,
+            "lifecycle_status": progress.lifecycle_status,
+            "stage": progress.stage,
+            "validation": validation,
+            "agent_actions": [validation["repair_action"]],
+        }
+
+    progress = load_progress(state)
+    if progress is None:
+        raise ValueError(f"Run 不存在：{run_id}")
+    action = progress.actions[action_id]
     action.status = "settled"
     save_progress(state, progress)
     result = resume_module_analysis(run_id, data_root)

--- a/src/pangea_agent/cli/adapter_api.py
+++ b/src/pangea_agent/cli/adapter_api.py
@@ -23,6 +23,7 @@ from pangea_agent.graph.workflow_store import (
     save_progress,
 )
 from pangea_agent.models.analysis import (
+    ActionState,
     AnalysisTask,
     ClosureTask,
     ComparisonReviewResult,
@@ -36,6 +37,57 @@ from pangea_agent.models.asset import AssetExtractionResult
 
 def _state(data_root: str, run_id: str) -> dict:
     return {"data_root": data_root, "run_id": run_id}
+
+
+def _originating_analysis_action(progress, run_id: str, action: ActionState) -> ActionState | None:
+    if action.role != "closure" or action.stage != "targeted_closure":
+        return None
+    unit_id = action.action_id.rsplit(":", 1)[-1]
+    origin_id = f"{run_id}:analysis:{unit_id}"
+    origin = progress.actions.get(origin_id)
+    if (
+        origin is None
+        or origin.role != "analysis"
+        or origin.stage != "unit_analysis"
+        or origin.status != "accepted"
+        or not origin.task_id
+    ):
+        raise ValueError(
+            "定向补齐必须续接该单元首轮 analysis worker，"
+            f"但 originating action 不可恢复：{origin_id}"
+        )
+    return origin
+
+
+def _external_action(progress, run_id: str, action: ActionState) -> dict:
+    payload = action.model_dump(mode="json")
+    origin = _originating_analysis_action(progress, run_id, action)
+    if origin is not None:
+        payload["action"] = "continue_agent"
+        payload["task_id"] = origin.task_id
+    return payload
+
+
+def _external_pending_actions(progress, run_id: str, limit: int = 8) -> list[dict]:
+    return [
+        _external_action(progress, run_id, progress.actions[item["action_id"]])
+        for item in pending_actions(progress, limit)
+    ]
+
+
+def _normalize_result_actions(data_root: str, run_id: str, result: dict) -> dict:
+    if not result.get("agent_actions"):
+        return result
+    progress = load_progress(_state(data_root, run_id))
+    if progress is None:
+        raise ValueError(f"Run 不存在：{run_id}")
+    payload = dict(result)
+    payload["agent_actions"] = [
+        _external_action(progress, run_id, progress.actions[item["action_id"]])
+        for item in result["agent_actions"]
+        if item.get("action_id") in progress.actions
+    ]
+    return payload
 
 
 def bind_asset_action(
@@ -98,7 +150,7 @@ def next_actions(data_root: str, run_id: str, limit: int = 8) -> dict:
     if progress is None:
         raise ValueError(f"Run 不存在：{run_id}")
     actions = sorted(
-        pending_actions(progress, limit),
+        _external_pending_actions(progress, run_id, limit),
         key=lambda item: item["action_id"],
     )
     return {
@@ -116,17 +168,27 @@ def bind_action(data_root: str, run_id: str, action_id: str, task_id: str) -> di
     progress = load_progress(state)
     if progress is None or action_id not in progress.actions:
         raise ValueError(f"Action 不存在：{action_id}")
+    action = progress.actions[action_id]
+    origin = _originating_analysis_action(progress, run_id, action)
+    if origin is not None and task_id != origin.task_id:
+        raise ValueError(
+            "定向补齐禁止新建或替换 worker："
+            f"expected_task_id={origin.task_id} actual_task_id={task_id}"
+        )
+    if action.task_id == task_id and action.status in {"dispatched", "accepted"}:
+        return _external_action(progress, run_id, action)
     if progress.lifecycle_status != "running":
         raise ValueError("Run 当前不接受新的 Agent 绑定")
-    action = progress.actions[action_id]
-    if action.status == "dispatched" and action.task_id == task_id:
-        return action.model_dump(mode="json")
     if action.status != "pending":
         raise ValueError(f"Action 当前不能绑定：status={action.status}")
-    action.task_id = task_id
+    if origin is not None:
+        action.action = "continue_agent"
+        action.task_id = origin.task_id
+    else:
+        action.task_id = task_id
     action.status = "dispatched"
     save_progress(state, progress)
-    return action.model_dump(mode="json")
+    return _external_action(progress, run_id, action)
 
 
 def _validate_planning(state: dict, task: PlanningTask, result: PlanningResult) -> None:
@@ -146,6 +208,8 @@ def validate_action(data_root: str, run_id: str, action_id: str) -> dict:
     if progress is None or action_id not in progress.actions:
         raise ValueError(f"Action 不存在：{action_id}")
     action = progress.actions[action_id]
+    if action.status == "accepted":
+        return {"action_id": action_id, "status": "valid", "already_accepted": True}
     task_path = Path(action.task_path)
     if action.role == "planning":
         task = PlanningTask.model_validate(read_json(task_path))
@@ -211,4 +275,5 @@ def settle_action(data_root: str, run_id: str, action_id: str) -> dict:
     validate_action(data_root, run_id, action_id)
     action.status = "settled"
     save_progress(state, progress)
-    return resume_module_analysis(run_id, data_root)
+    result = resume_module_analysis(run_id, data_root)
+    return _normalize_result_actions(data_root, run_id, result)

--- a/src/pangea_agent/cli/adapter_api.py
+++ b/src/pangea_agent/cli/adapter_api.py
@@ -81,12 +81,14 @@ def _normalize_result_actions(data_root: str, run_id: str, result: dict) -> dict
     progress = load_progress(_state(data_root, run_id))
     if progress is None:
         raise ValueError(f"Run 不存在：{run_id}")
+    normalized = []
+    for item in result["agent_actions"]:
+        action_id = item.get("action_id")
+        if not action_id or action_id not in progress.actions:
+            raise ValueError(f"Workflow 返回了未持久化的 action：{action_id}")
+        normalized.append(_external_action(progress, run_id, progress.actions[action_id]))
     payload = dict(result)
-    payload["agent_actions"] = [
-        _external_action(progress, run_id, progress.actions[item["action_id"]])
-        for item in result["agent_actions"]
-        if item.get("action_id") in progress.actions
-    ]
+    payload["agent_actions"] = normalized
     return payload
 
 
@@ -175,7 +177,7 @@ def bind_action(data_root: str, run_id: str, action_id: str, task_id: str) -> di
             "定向补齐禁止新建或替换 worker："
             f"expected_task_id={origin.task_id} actual_task_id={task_id}"
         )
-    if action.task_id == task_id and action.status in {"dispatched", "accepted"}:
+    if action.task_id == task_id and action.status in {"dispatched", "settled", "accepted"}:
         return _external_action(progress, run_id, action)
     if progress.lifecycle_status != "running":
         raise ValueError("Run 当前不接受新的 Agent 绑定")
@@ -268,6 +270,9 @@ def settle_action(data_root: str, run_id: str, action_id: str) -> dict:
     action = progress.actions[action_id]
     if action.status == "accepted":
         return next_actions(data_root, run_id)
+    if action.status == "settled":
+        result = resume_module_analysis(run_id, data_root)
+        return _normalize_result_actions(data_root, run_id, result)
     if progress.lifecycle_status != "running":
         raise ValueError("Run 当前不接受 Agent 结果")
     if action.status != "dispatched" or not action.task_id:

--- a/tests/test_recovery_contracts.py
+++ b/tests/test_recovery_contracts.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from pangea_agent.agent_io import write_json
+from pangea_agent.cli.adapter_api import bind_action, next_actions, validate_action
+from pangea_agent.graph.workflow_store import load_progress, save_progress
+from pangea_agent.models.analysis import ActionState, WorkflowProgress
+
+
+class RecoveryContractTests(unittest.TestCase):
+    def _state(self, root: str, run_id: str = "RUN-RECOVERY") -> dict:
+        return {"data_root": root, "run_id": run_id}
+
+    def test_closure_reuses_originating_analysis_worker(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            state = self._state(root)
+            Path(root, "runs", state["run_id"]).mkdir(parents=True)
+            progress = WorkflowProgress(
+                run_id=state["run_id"],
+                stage="closing",
+                actions={
+                    f'{state["run_id"]}:analysis:U01': ActionState(
+                        action_id=f'{state["run_id"]}:analysis:U01',
+                        action="dispatch_agent",
+                        role="analysis",
+                        stage="unit_analysis",
+                        task_path="analysis-U01.json",
+                        task_id="analysis-agent-1",
+                        status="accepted",
+                    ),
+                    f'{state["run_id"]}:closure:U01': ActionState(
+                        action_id=f'{state["run_id"]}:closure:U01',
+                        action="dispatch_agent",
+                        role="closure",
+                        stage="targeted_closure",
+                        task_path="closure-U01.json",
+                        status="pending",
+                    ),
+                },
+            )
+            save_progress(state, progress)
+
+            exposed = next_actions(root, state["run_id"])["actions"]
+            self.assertEqual(len(exposed), 1)
+            self.assertEqual(exposed[0]["action"], "continue_agent")
+            self.assertEqual(exposed[0]["task_id"], "analysis-agent-1")
+
+            with self.assertRaisesRegex(ValueError, "禁止新建或替换 worker"):
+                bind_action(
+                    root,
+                    state["run_id"],
+                    f'{state["run_id"]}:closure:U01',
+                    "replacement-agent",
+                )
+
+            bound = bind_action(
+                root,
+                state["run_id"],
+                f'{state["run_id"]}:closure:U01',
+                "analysis-agent-1",
+            )
+            self.assertEqual(bound["action"], "continue_agent")
+            self.assertEqual(bound["task_id"], "analysis-agent-1")
+            stored = load_progress(state)
+            assert stored is not None
+            closure = stored.actions[f'{state["run_id"]}:closure:U01']
+            self.assertEqual(closure.status, "dispatched")
+            self.assertEqual(closure.action, "continue_agent")
+            self.assertEqual(closure.task_id, "analysis-agent-1")
+
+    def test_accepted_action_validation_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            state = self._state(root)
+            Path(root, "runs", state["run_id"]).mkdir(parents=True)
+            action_id = f'{state["run_id"]}:analysis:U01'
+            save_progress(
+                state,
+                WorkflowProgress(
+                    run_id=state["run_id"],
+                    stage="reviewing",
+                    actions={
+                        action_id: ActionState(
+                            action_id=action_id,
+                            action="dispatch_agent",
+                            role="analysis",
+                            stage="unit_analysis",
+                            task_path="already-accepted.json",
+                            task_id="analysis-agent-1",
+                            status="accepted",
+                        )
+                    },
+                ),
+            )
+
+            validated = validate_action(root, state["run_id"], action_id)
+            self.assertEqual(validated["status"], "valid")
+            self.assertTrue(validated["already_accepted"])
+
+    def test_missing_canonical_analysis_result_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            state = self._state(root)
+            run_dir = Path(root, "runs", state["run_id"])
+            run_dir.mkdir(parents=True)
+            task_path = run_dir / "analysis-task.json"
+            selected_inputs_path = run_dir / "selected-inputs.json"
+            missing_result_path = run_dir / "agent-results" / "analysis" / "U01.json"
+            write_json(selected_inputs_path, {
+                "asset_items": {},
+                "defect_mechanisms": {},
+                "coverage_gaps": [],
+                "test_case_examples": [],
+            })
+            write_json(task_path, {
+                "schema_version": "1.0",
+                "task_type": "analysis",
+                "run_id": state["run_id"],
+                "target": "module",
+                "unit": {
+                    "unit_id": "U01",
+                    "repo_id": "repo",
+                    "title": "unit",
+                    "source_scope": ["src/a.c"],
+                    "context_scope": [],
+                    "rationale": "test",
+                    "asset_item_ids": [],
+                    "coverage_ids": [],
+                    "mechanism_ids": [],
+                    "line_count": 1,
+                    "function_count": 1,
+                },
+                "repository": {
+                    "repo_id": "repo",
+                    "source_root": ".",
+                    "git": {},
+                },
+                "inventory_path": str(run_dir / "inventory.json"),
+                "source_manifest_path": str(run_dir / "source-manifest.json"),
+                "selected_inputs_path": str(selected_inputs_path),
+                "coverage_context": [],
+                "result_schema_path": "schemas/analysis_result.schema.json",
+                "result_path": str(missing_result_path),
+                "rubric_paths": ["rubric.md"],
+            })
+            action_id = f'{state["run_id"]}:analysis:U01'
+            save_progress(
+                state,
+                WorkflowProgress(
+                    run_id=state["run_id"],
+                    stage="analyzing",
+                    actions={
+                        action_id: ActionState(
+                            action_id=action_id,
+                            action="dispatch_agent",
+                            role="analysis",
+                            stage="unit_analysis",
+                            task_path=str(task_path),
+                            task_id="analysis-agent-1",
+                            status="dispatched",
+                        )
+                    },
+                ),
+            )
+
+            with self.assertRaises(FileNotFoundError):
+                validate_action(root, state["run_id"], action_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recovery_contracts.py
+++ b/tests/test_recovery_contracts.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from pangea_agent.agent_io import write_json
-from pangea_agent.cli.adapter_api import bind_action, next_actions, validate_action
+from pangea_agent.cli.adapter_api import (
+    bind_action,
+    next_actions,
+    settle_action,
+    validate_action,
+)
 from pangea_agent.graph.workflow_store import load_progress, save_progress
 from pangea_agent.models.analysis import ActionState, WorkflowProgress
 
@@ -98,6 +104,44 @@ class RecoveryContractTests(unittest.TestCase):
             validated = validate_action(root, state["run_id"], action_id)
             self.assertEqual(validated["status"], "valid")
             self.assertTrue(validated["already_accepted"])
+
+    def test_settled_action_can_be_settled_again_before_batch_advances(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            state = self._state(root)
+            Path(root, "runs", state["run_id"]).mkdir(parents=True)
+            action_id = f'{state["run_id"]}:analysis:U01'
+            save_progress(
+                state,
+                WorkflowProgress(
+                    run_id=state["run_id"],
+                    stage="analyzing",
+                    actions={
+                        action_id: ActionState(
+                            action_id=action_id,
+                            action="dispatch_agent",
+                            role="analysis",
+                            stage="unit_analysis",
+                            task_path="settled.json",
+                            task_id="analysis-agent-1",
+                            status="settled",
+                        )
+                    },
+                ),
+            )
+
+            with patch(
+                "pangea_agent.cli.adapter_api.resume_module_analysis",
+                return_value={
+                    "run_id": state["run_id"],
+                    "data_root": root,
+                    "stage": "analyzing",
+                    "agent_actions": [],
+                },
+            ) as resume:
+                result = settle_action(root, state["run_id"], action_id)
+
+            resume.assert_called_once_with(state["run_id"], root)
+            self.assertEqual(result["stage"], "analyzing")
 
     def test_missing_canonical_analysis_result_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as root:

--- a/tests/test_recovery_contracts.py
+++ b/tests/test_recovery_contracts.py
@@ -12,6 +12,7 @@ from pangea_agent.cli.adapter_api import (
     settle_action,
     validate_action,
 )
+from pangea_agent.graph.nodes.advance_workflow import advance_workflow
 from pangea_agent.graph.workflow_store import load_progress, save_progress
 from pangea_agent.models.analysis import ActionState, WorkflowProgress
 
@@ -19,6 +20,69 @@ from pangea_agent.models.analysis import ActionState, WorkflowProgress
 class RecoveryContractTests(unittest.TestCase):
     def _state(self, root: str, run_id: str = "RUN-RECOVERY") -> dict:
         return {"data_root": root, "run_id": run_id}
+
+    def _write_analysis_task(self, state: dict, *, status: str = "dispatched") -> tuple[str, Path]:
+        run_dir = Path(state["data_root"], "runs", state["run_id"])
+        task_path = run_dir / "agent-tasks" / "analysis" / "U01.json"
+        selected_inputs_path = run_dir / "inputs" / "units" / "U01.json"
+        missing_result_path = run_dir / "agent-results" / "analysis" / "U01.json"
+        write_json(selected_inputs_path, {
+            "asset_items": {},
+            "defect_mechanisms": {},
+            "coverage_gaps": [],
+            "test_case_examples": [],
+        })
+        write_json(task_path, {
+            "schema_version": "1.0",
+            "task_type": "analysis",
+            "run_id": state["run_id"],
+            "target": "module",
+            "unit": {
+                "unit_id": "U01",
+                "repo_id": "repo",
+                "title": "unit",
+                "source_scope": ["src/a.c"],
+                "context_scope": [],
+                "rationale": "test",
+                "asset_item_ids": [],
+                "coverage_ids": [],
+                "mechanism_ids": [],
+                "line_count": 1,
+                "function_count": 1,
+            },
+            "repository": {
+                "repo_id": "repo",
+                "source_root": ".",
+                "git": {},
+            },
+            "inventory_path": str(run_dir / "inputs" / "inventory.json"),
+            "source_manifest_path": str(run_dir / "inputs" / "source-manifest.json"),
+            "selected_inputs_path": str(selected_inputs_path),
+            "coverage_context": [],
+            "result_schema_path": "schemas/analysis_result.schema.json",
+            "result_path": str(missing_result_path),
+            "rubric_paths": ["rubric.md"],
+        })
+        action_id = f'{state["run_id"]}:analysis:U01'
+        save_progress(
+            state,
+            WorkflowProgress(
+                run_id=state["run_id"],
+                stage="analyzing",
+                actions={
+                    action_id: ActionState(
+                        action_id=action_id,
+                        action="dispatch_agent",
+                        role="analysis",
+                        stage="unit_analysis",
+                        task_path=str(task_path),
+                        task_id="analysis-agent-1",
+                        status=status,
+                    )
+                },
+            ),
+        )
+        return action_id, missing_result_path
 
     def test_closure_reuses_originating_analysis_worker(self) -> None:
         with tempfile.TemporaryDirectory() as root:
@@ -143,73 +207,33 @@ class RecoveryContractTests(unittest.TestCase):
             resume.assert_called_once_with(state["run_id"], root)
             self.assertEqual(result["stage"], "analyzing")
 
-    def test_missing_canonical_analysis_result_is_rejected(self) -> None:
+    def test_missing_canonical_analysis_result_is_rejected_by_adapter(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             state = self._state(root)
-            run_dir = Path(root, "runs", state["run_id"])
-            run_dir.mkdir(parents=True)
-            task_path = run_dir / "analysis-task.json"
-            selected_inputs_path = run_dir / "selected-inputs.json"
-            missing_result_path = run_dir / "agent-results" / "analysis" / "U01.json"
-            write_json(selected_inputs_path, {
-                "asset_items": {},
-                "defect_mechanisms": {},
-                "coverage_gaps": [],
-                "test_case_examples": [],
-            })
-            write_json(task_path, {
-                "schema_version": "1.0",
-                "task_type": "analysis",
-                "run_id": state["run_id"],
-                "target": "module",
-                "unit": {
-                    "unit_id": "U01",
-                    "repo_id": "repo",
-                    "title": "unit",
-                    "source_scope": ["src/a.c"],
-                    "context_scope": [],
-                    "rationale": "test",
-                    "asset_item_ids": [],
-                    "coverage_ids": [],
-                    "mechanism_ids": [],
-                    "line_count": 1,
-                    "function_count": 1,
-                },
-                "repository": {
-                    "repo_id": "repo",
-                    "source_root": ".",
-                    "git": {},
-                },
-                "inventory_path": str(run_dir / "inventory.json"),
-                "source_manifest_path": str(run_dir / "source-manifest.json"),
-                "selected_inputs_path": str(selected_inputs_path),
-                "coverage_context": [],
-                "result_schema_path": "schemas/analysis_result.schema.json",
-                "result_path": str(missing_result_path),
-                "rubric_paths": ["rubric.md"],
-            })
-            action_id = f'{state["run_id"]}:analysis:U01'
-            save_progress(
-                state,
-                WorkflowProgress(
-                    run_id=state["run_id"],
-                    stage="analyzing",
-                    actions={
-                        action_id: ActionState(
-                            action_id=action_id,
-                            action="dispatch_agent",
-                            role="analysis",
-                            stage="unit_analysis",
-                            task_path=str(task_path),
-                            task_id="analysis-agent-1",
-                            status="dispatched",
-                        )
-                    },
-                ),
-            )
+            action_id, _ = self._write_analysis_task(state)
 
             with self.assertRaises(FileNotFoundError):
                 validate_action(root, state["run_id"], action_id)
+
+    def test_missing_analysis_result_cannot_silently_skip_review(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            state = self._state(root)
+            action_id, missing_result = self._write_analysis_task(state, status="settled")
+            self.assertFalse(missing_result.exists())
+
+            with self.assertRaises(FileNotFoundError):
+                advance_workflow({
+                    **state,
+                    "task_contract": {"target": "module"},
+                })
+
+            failed = load_progress(state)
+            assert failed is not None
+            self.assertEqual(failed.lifecycle_status, "failed")
+            self.assertEqual(failed.actions[action_id].status, "failed")
+            self.assertFalse(
+                any(action.role == "review" for action in failed.actions.values())
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_recovery_contracts.py
+++ b/tests/test_recovery_contracts.py
@@ -207,13 +207,46 @@ class RecoveryContractTests(unittest.TestCase):
             resume.assert_called_once_with(state["run_id"], root)
             self.assertEqual(result["stage"], "analyzing")
 
-    def test_missing_canonical_analysis_result_is_rejected_by_adapter(self) -> None:
+    def test_missing_canonical_analysis_result_returns_repair_action(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             state = self._state(root)
             action_id, _ = self._write_analysis_task(state)
 
-            with self.assertRaises(FileNotFoundError):
-                validate_action(root, state["run_id"], action_id)
+            validation = validate_action(root, state["run_id"], action_id)
+
+            self.assertEqual(validation["status"], "invalid")
+            self.assertTrue(validation["recoverable"])
+            self.assertEqual(validation["repair_action"]["action"], "continue_agent")
+            self.assertEqual(
+                validation["repair_action"]["task_id"], "analysis-agent-1"
+            )
+            self.assertEqual(validation["repair_action"]["action_id"], action_id)
+            stored = load_progress(state)
+            assert stored is not None
+            self.assertEqual(stored.lifecycle_status, "running")
+            self.assertEqual(stored.actions[action_id].status, "dispatched")
+            self.assertIsNotNone(stored.actions[action_id].error)
+
+    def test_settle_does_not_advance_when_validation_is_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            state = self._state(root)
+            action_id, _ = self._write_analysis_task(state)
+
+            with patch(
+                "pangea_agent.cli.adapter_api.resume_module_analysis"
+            ) as resume:
+                result = settle_action(root, state["run_id"], action_id)
+
+            resume.assert_not_called()
+            self.assertEqual(result["validation"]["status"], "invalid")
+            self.assertEqual(result["agent_actions"][0]["action"], "continue_agent")
+            self.assertEqual(
+                result["agent_actions"][0]["task_id"], "analysis-agent-1"
+            )
+            stored = load_progress(state)
+            assert stored is not None
+            self.assertEqual(stored.lifecycle_status, "running")
+            self.assertEqual(stored.actions[action_id].status, "dispatched")
 
     def test_missing_analysis_result_cannot_silently_skip_review(self) -> None:
         with tempfile.TemporaryDirectory() as root:


### PR DESCRIPTION
## Why

Recent root-cause fixes were implemented on `agent/worker-result-index-path-fix`, but the affected runtime is `codex/pangea-workflow-rebuild`. The two branches have diverged substantially, so this PR ports only the behavioral contracts onto the rebuilt workflow instead of merging/cherry-picking the legacy Graph implementation.

## Recovery changes

- Keep `codex/pangea-workflow-rebuild` as the sole architecture baseline.
- Expose `targeted_closure` as `continue_agent` using the originating analysis worker `task_id`.
- Reject any attempt to bind closure to a replacement/new worker.
- Teach OpenCode / Claude / DSH analysis workers to handle formal closure tasks in the original session and preserve the prior result as the content base.
- Make accepted validation and settled action retries idempotent.
- Reject workflow-returned actions that were not persisted instead of silently dropping them.
- Add regression tests proving:
  - closure reuses the originating analysis worker;
  - replacement worker binding is rejected;
  - accepted validation is retry-safe;
  - repeated settle before a parallel batch advances is retry-safe;
  - missing canonical analysis result is rejected;
  - missing analysis result cannot silently skip review.

## Deliberately not ported

No `run_store`, `advance_run`, old worker-result schema, old phase-rank logic, or other legacy Graph files are copied from `agent/worker-result-index-path-fix`.

## Verification

Static review completed. Local container could not resolve github.com, so pytest could not be run from a fresh clone in this session. Keep this PR draft until repository CI / local verification passes.